### PR TITLE
Fix markdown table rendering on Github page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: vSphere Supervisor Services
+description: vSphere with Tanzu | Supervisor Services
+markdown: GFM


### PR DESCRIPTION
Switches the jekyll markdown rendering to GFM so the compatibility table displays correctly on Github page.

Based on the suggestion from this issue: https://github.com/pages-themes/cayman/issues/82

## Testing Done: 
Ran jekyll server locally and observed the site rendering as expected.

<img width="1118" alt="markdown-table-fix-github-sites" src="https://github.com/vsphere-tmm/Supervisor-Services/assets/1851202/f6dd1692-ea5f-4e06-b511-7d6d6646e711">


