### PR TITLE
TKG Service: include interop link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ VMware Tanzu Kubernetes Grid Service (TKG Service) lets you deploy Kubernetes wo
 - [TKG Service v3.1.0](https://packages.broadcom.com/artifactory/vsphere-distro/vsphere/iaas/kubernetes-service/3.1.0-package.yaml)
   - [Release Notes](https://docs.vmware.com/en/VMware-vSphere/8/rn/vmware-tanzu-kubernetes-grid-service-release-notes/index.html#TKG%20Service%203.1)
   - [OSS Information](https://packages.broadcom.com/artifactory/vsphere-distro/vsphere/iaas/kubernetes-service/3.1.0-package.open_source_license.txt)
-    
+  - [Interoperability Matrix](https://interopmatrix.vmware.com/Interoperability?col=820,17000,18237,17284,18034,18430,18431&row=2,%261794,&isHidePatch=false&isHideLegacyReleases=false) showing compatible Kubernetes releases
+
 
 ## Consumption Interface
 


### PR DESCRIPTION
Add a deep-link to the most view of the interop matrix most relevant to the TKG Service 3.1.0 release to help users understand compatible Kubernetes releases, without duplicating information (so that content does not risk becoming outdated).