### PR TITLE
Grafana Operator Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,11 +382,11 @@ Grafana Operator is a Kubernetes operator built to help you manage your Grafana 
 
 ### Grafana Operator Versions
 
-- Download latest version: [Grafana Operator v5.9.0](supervisor-services-labs/grafana-operator/v5.9.0/grafana-operator.yaml).
+- Download latest version: [Grafana Operator v5.15.0](supervisor-services-labs/grafana-operator/v5.15.0/grafana-operator.yaml).
 
-Grafana Operator Sample `values.yaml` -
+Grafana Operator Sample `values.yaml` for v5.15.0 - [values.yaml](supervisor-services-labs/grafana-operator/v5.15.0/values.yaml)
 
-- We do not provide this package's default `values.yaml`. This operator requires minimal configurations, and the necessary pods get deployed in the `svc-grafana-operatorxxx` namespace.
+- The sample `values.yaml` for the latest version has been provided above. This operator requires minimal configurations, and the necessary pods get deployed in the `svc-grafana-operator-xxx` namespace.
 
 #### Usage:
 

--- a/supervisor-services-labs/grafana-operator/v5.15.0/grafana-operator.yaml
+++ b/supervisor-services-labs/grafana-operator/v5.15.0/grafana-operator.yaml
@@ -1,6 +1,7 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: PackageMetadata
 metadata:
+  creationTimestamp: null
   name: grafana-operator.fling.vsphere.vmware.com
 spec:
   categories:
@@ -8,7 +9,7 @@ spec:
   - Observability
   displayName: grafana-operator
   iconSVGBase64: none
-  longDescription: The Grafana Operator is a Kubernetes operator built to help you manage your Grafana instances and its resources in and outside of Kubernetes. Whether you’re running one Grafana instance or many, the Grafana Operator simplifies the processes of installing, configuring, and maintaining Grafana and its resources. Additionally, it's perfect for those who prefer to manage resources using infrastructure as code or using GitOps workflows through tools like ArgoCD and Flux CD.
+  longDescription: The Grafana Operator is a Kubernetes operator built to help you manage your Grafana instances and its resources in and outside of Kubernetes. Whether you’re running one Grafana instance or many, the Grafana Operator simplifies the processes of installing, configuring, and maintaining Grafana and its resources. Additionally, it's perfect for those who prefer to manage resources using infrastructure as code or using GitOps workflows through tools like ArgoCD and Flux CD. 
   maintainers:
   - name: supervisor-services-labs.pdl@broadcom.com
   providerName: VMware
@@ -17,17 +18,18 @@ spec:
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: grafana-operator.fling.vsphere.vmware.com.5.9.0
+  creationTimestamp: null
+  name: grafana-operator.fling.vsphere.vmware.com.5.15.0
 spec:
   refName: grafana-operator.fling.vsphere.vmware.com
-  releasedAt: "2024-05-13T23:41:36Z"
+  releasedAt: "2024-11-06T21:00:17Z"
   template:
     spec:
       deploy:
       - kapp: {}
       fetch:
       - imgpkgBundle:
-          image: projects.registry.vmware.com/vsphere-labs/grafana-operator@sha256:a74b04131c238e08ad4330bc04ac6d82ac00b38f90da48119fc2d95b5458f413
+          image: projects.packages.broadcom.com/vsphere-labs/grafana-operator@sha256:b3d21e4adf129add6d20d72f7ba51a3e0fc1b69feb6c3fc30a18f314811a01e8
       template:
       - ytt:
           paths:
@@ -40,4 +42,4 @@ spec:
     openAPIv3:
       default: null
       nullable: true
-  version: 5.9.0
+  version: 5.15.0

--- a/supervisor-services-labs/grafana-operator/v5.15.0/values.yaml
+++ b/supervisor-services-labs/grafana-operator/v5.15.0/values.yaml
@@ -1,0 +1,2 @@
+# To reference the grafana-operator:tag hosted on an alternate/registry, modify the value of the image field.
+image: ghcr.io/grafana/grafana-operator:v5.15.0


### PR DESCRIPTION
The Grafana Operator was not migrated to Artifactory during the registry migration process. This request fixes the issue. The Operator file has been updated to version 5.15.0 and a new values. The `values.yaml` file has been included for air-gapped installations. 