### PR TITLE
Update interop matrix URLs to use new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ VMware Tanzu Kubernetes Grid Service (TKG Service) lets you deploy Kubernetes wo
 - Download latest version [TKG Service v3.2.0](https://packages.broadcom.com/artifactory/vsphere-distro/vsphere/iaas/kubernetes-service/3.2.0-package.yaml)
   - [Release Notes](https://docs.vmware.com/en/VMware-vSphere/8/rn/vmware-tanzu-kubernetes-grid-service-release-notes/index.html#TKG%20Service%203.2)
   - [OSS Information](https://packages.broadcom.com/artifactory/vsphere-distro/vsphere/iaas/kubernetes-service/3.2.0-package.open_source_license.txt)
-  - [Interoperability Matrix](https://interopmatrix.vmware.com/Interoperability?col=820,17000,18237,17284,18034,18430,18431,18448&row=2,%261794,&isHidePatch=false&isHideLegacyReleases=false) showing compatible Kubernetes releases
+  - [Interoperability Matrix](https://interopmatrix.broadcom.com/Interoperability?col=820,17000,18237,17284,18034,18430,18431,18448&row=2,%261794,&isHidePatch=false&isHideLegacyReleases=false) showing compatible Kubernetes releases
 - Download [TKG Service v3.1.0](https://packages.broadcom.com/artifactory/vsphere-distro/vsphere/iaas/kubernetes-service/3.1.0-package.yaml)
   - [Release Notes](https://docs.vmware.com/en/VMware-vSphere/8/rn/vmware-tanzu-kubernetes-grid-service-release-notes/index.html#TKG%20Service%203.1)
   - [OSS Information](https://packages.broadcom.com/artifactory/vsphere-distro/vsphere/iaas/kubernetes-service/3.1.0-package.open_source_license.txt)
-  - [Interoperability Matrix](https://interopmatrix.vmware.com/Interoperability?col=820,17000,18237,17284,18034,18430,18431&row=2,%261794,&isHidePatch=false&isHideLegacyReleases=false) showing compatible Kubernetes releases
+  - [Interoperability Matrix](https://interopmatrix.broadcom.com/Interoperability?col=820,17000,18237,17284,18034,18430,18431&row=2,%261794,&isHidePatch=false&isHideLegacyReleases=false) showing compatible Kubernetes releases
 
 
 ## Consumption Interface


### PR DESCRIPTION
The interop matrix tool has moved from interopmatrix.vmware.com to interopmatrix.broadcom.com. A redirect is in place, but it does not yet preserve URL query parameters. Updating the URL to ensure readers find the expected information.