### PR TITLE
Add NSX Management Proxy v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ NSX Management Proxy is for Antrea-NSX adapter in TKG workload cluster to reach 
 
 ### NSX Management Proxy Versions
 
-- Download latest version: [nsx-management-proxy v0.2.0](https://vmwaresaas.jfrog.io/ui/api/v1/download?repoKey=supervisor-services&path=nsx-management-proxy/v0.2.0/nsx-management-proxy.yml)
+- Download latest version: [nsx-management-proxy v0.2.1](https://vmwaresaas.jfrog.io/ui/api/v1/download?repoKey=supervisor-services&path=nsx-management-proxy/v0.2.1/nsx-management-proxy.yml)
+- Download version: [nsx-management-proxy v0.2.0](https://vmwaresaas.jfrog.io/ui/api/v1/download?repoKey=supervisor-services&path=nsx-management-proxy/v0.2.0/nsx-management-proxy.yml)
 - Download version: [nsx-management-proxy v0.1.1](https://vmwaresaas.jfrog.io/ui/api/v1/download?repoKey=supervisor-services&path=nsx-management-proxy/v0.1.1/nsx-management-proxy.yml)
 
 NSX Management Proxy Sample `values.yaml`


### PR DESCRIPTION
Fix dynamic HTTP CONNECT proxy for NSX-RPC traffic.

Dynamic HTTP CONNECT proxy didn't work in recent release 0.2 after we upgraded to Envoy v1.30 as there is a behaviour change in recent Envoy release. It will forward the client HTTP CONNECT request by default to the upstream servers.
See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routeaction-upgradeconfig
This behaviour change resulted in connection failure for NSX-RPC traffic.

This behaviour change is not what we want. We want Envoy to remove the client HTTP CONNECT request and forward the raw traffic which comes after the HTTP CONNECT request. We fixed this by explicitly adding an empty connect_config. 
See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routeaction-upgradeconfig-connectconfig