### PR TITLE
Add 8.0U3 installation warning to 9.0 release notes.

### DIFF
--- a/consumption-interface/Release_Notes_9_0_0.md
+++ b/consumption-interface/Release_Notes_9_0_0.md
@@ -39,8 +39,8 @@ Admins can provide a link to launch LCI independent of granting access to the vS
 - For 8.0U3 installations: Occasionally, the plug-in may fail to load on the initial
 attempt. To check if the plug-in has loaded correctly, click the **vSphere Client**
 menu icon, then to **Administration** -> **Client** -> **Plug-ins**.
-Check the Status column of the Namespace UI plug-in, and in case you see a "Plug-in
-configuration with Reverse Proxy failed." Message, reinstall the plug-in
+Check the Status column of the Namespace UI plug-in, and in case you see a *Plug-in
+configuration with Reverse Proxy failed.* message, reinstall the plug-in
 
 - You must uninstall version 1.0.x before using the 9.0.0 version of LCI. Failure to do so will result in the interface not starting correctly when looking at the `Resources` tab for a namespace.
 

--- a/consumption-interface/Release_Notes_9_0_0.md
+++ b/consumption-interface/Release_Notes_9_0_0.md
@@ -34,7 +34,13 @@ Please see the documentation for these variables here: [ClusterClass Variables f
 ## Standalone LCI
 Admins can provide a link to launch LCI independent of granting access to the vSphere client
 
-## Known Issues
+# Known Issues
+
+- For 8.0U3 installations: Occasionally, the plug-in may fail to load on the initial
+attempt. To check if the plug-in has loaded correctly, click the **vSphere Client**
+menu icon, then to **Administration** -> **Client** -> **Plug-ins**.
+Check the Status column of the Namespace UI plug-in, and in case you see a "Plug-in
+configuration with Reverse Proxy failed." Message, reinstall the plug-in
 
 - You must uninstall version 1.0.x before using the 9.0.0 version of LCI. Failure to do so will result in the interface not starting correctly when looking at the `Resources` tab for a namespace.
 


### PR DESCRIPTION
We did not carry the 8.0U3 warning to the 9.0 release notes. Adding to these as well as the issue was already hit by an internal user.