### PR TITLE
[GCM-15024] Update LCI release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Prior to vSphere 8 Update 1, the Supervisor Services are only available with Sup
 
   - [vSphere Kubernetes Service (VKS)](#vsphere-kubernetes-service)
     - [vSphere Kubernetes Service (VKS) Versions](#vsphere-kubernetes-service-versions)
-  - [Local Consumption Interface](#consumption-interface)
-    - [Local Consumption Interface Versions](#consumption-interface-versions)
+  - [Local Consumption Interface](#local-consumption-interface)
+    - [Local Consumption Interface Versions](#local-consumption-interface-versions)
   - [vSAN Data Persistence Platform (vDPP) Services:](#vsan-data-persistence-platform-vdpp-services)
   - [Backup \& Recovery Service](#backup--recovery-service)
     - [Velero vSphere Operator CLI Versions](#velero-vsphere-operator-cli-versions)

--- a/consumption-interface/Release_Notes_1_0_2.md
+++ b/consumption-interface/Release_Notes_1_0_2.md
@@ -24,7 +24,7 @@ Known Issues
 
 - There is a known issue in the TKG cluster creation wizard. If a user works backward through the wizard, some configuration may be lost. Users should execute the wizard end-to-end in sequence.
 
-- In 8.0U3 installations, LCI 1.0.2 does not support the features introduced in VKS 3.2 or higher. These features are supported in newer release of LCI i.e. in LCI 9.0.0 or higher.
+- In 8.0U3 installations, LCI 1.0.2 does not support the features introduced in VKS 3.2 or higher. These features are supported in newer releases of LCI i.e. from LCI [9.0.0](./Release_Notes_9_0_0.md) onwards.
 
 - Resource updates will not automatically refresh in the UI. Users need to use the reload button to refresh the views on the resources.
 

--- a/consumption-interface/Release_Notes_1_0_2.md
+++ b/consumption-interface/Release_Notes_1_0_2.md
@@ -24,6 +24,8 @@ Known Issues
 
 - There is a known issue in the TKG cluster creation wizard. If a user works backward through the wizard, some configuration may be lost. Users should execute the wizard end-to-end in sequence.
 
+- In 8.0U3 installations, LCI 1.0.2 does not support the features introduced in VKS 3.2 or higher. These features are supported in newer release of LCI i.e. in LCI 9.0.0 or higher.
+
 - Resource updates will not automatically refresh in the UI. Users need to use the reload button to refresh the views on the resources.
 
 - [Previous release notes](./Release_Notes_1_0_1.md)

--- a/consumption-interface/Release_Notes_9_0_0.md
+++ b/consumption-interface/Release_Notes_9_0_0.md
@@ -13,11 +13,10 @@ Known issues and limitations of the Consumption Interface Supervisor Service
 
 ## VKS
 - LCI 9.0.0 is compatible with VKS v3.0 through v3.4, and can be used for managing the lifecycle of clusters with any of these versions.
-- However, LCI 9.0.0 does not support functionality introduced in VKS 3.3 and VKS 3.4. This will be addressed in a future LCI release.
+- However, LCI 9.0.0 does not support the features introduced in VKS 3.3 and VKS 3.4. These features will be supported in a future LCI release.
 - New features
     - Add support for consuming multiple Content Libraries configured for Kubernetes Service on Supervisor for both Cluster and TanzuKubernetesCluster API
     - Add support for vSphere Zones for both Cluster and TanzuKubernetesCluster API
-    - Ability to configure a Windows node pool to use Group Managed Service Accounts
     - Introduced following Cluster Day 2 actions
         - Increase Replicas
         - Update VM Class

--- a/consumption-interface/Release_Notes_9_0_1.md
+++ b/consumption-interface/Release_Notes_9_0_1.md
@@ -23,16 +23,19 @@
 - For 8.0U3 installations: 
     - Occasionally, the plug-in may fail to load on the initial attempt. To check if the plug-in has loaded correctly, click the **vSphere Client** menu icon, then to **Administration** -> **Client** -> **Plug-ins**. Check the Status column of the VMware Local Consumption Interface plug-in, and in case you see a *Plug-in Configuration with Reverse Proxy failed.* message, reinstall the plug-in.
     - VKS will not support following features:
-        - Ability to retire a TKC is not supported and hence the upgrade from VKr 1.32.x --> 1.33.x for a TKC will fail.
+        - Ability to retire a TKC and upgrade a TKC from VKr 1.32.x --> 1.33.x is not available.
         - Ability to configure a Windows node pool to use Group Managed Service Accounts.
         - Ability to upgrade a CAPI Cluster with atleast one Ubuntu worker nodes from VKr 1.32.x --> 1.33.x
-        - Cluster class 3.4.0 and VKr 1.33.x and higher.
+        - ClusterClass 3.4.0 onwards, VKr 1.33.x and higher.
 
 - You must uninstall version 1.0.x before using the 9.0.x version of LCI. Failure to do so will result in the interface not starting correctly when looking at the `Resources` tab for a namespace.
 
 - The UI allows users to publish VKS cluster VMs that are currently deployed. The published image will not be usable and users should not leverage this feature for such VMs.
 
-- When using the VKS IaaS plugin, you must enter a new value on the volume dialog when adding a volume.
+- In VKS IaaS plugin:
+    - You must enter a new value on the volume dialog when adding a volume.
+    - To upgrade a Cluster created from a retired TKC, first remove "kubernetes.vmware.com/skip-auto-cc-rebase: ''" annotation from Cluster yaml before proceeding to upgrade the Cluster.
+    - To upgrade a Cluster to a VKR containing multiple Ubuntu OS versions, first edit the Cluster YAML and add 'os-version' field to the annotation before proceeding to upgrade the Cluster.
 
 - Resource updates will not automatically refresh in the UI. Users need to use the reload button to refresh the views on the resources.
 

--- a/consumption-interface/Release_Notes_9_0_1.md
+++ b/consumption-interface/Release_Notes_9_0_1.md
@@ -33,7 +33,7 @@
 - The UI allows users to publish VKS cluster VMs that are currently deployed. The published image will not be usable and users should not leverage this feature for such VMs.
 
 - In VKS IaaS plugin:
-    - You must enter a new value on the volume dialog when adding a volume.
+    - You must enter or modify a new value on any field in the dialog when adding a volume.
     - To upgrade a Cluster created from a retired TKC, first remove "kubernetes.vmware.com/skip-auto-cc-rebase: ''" annotation by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
     - To upgrade a Cluster to a VKR containing multiple Ubuntu OS versions, add 'os-version' field to the annotations by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
 

--- a/consumption-interface/Release_Notes_9_0_1.md
+++ b/consumption-interface/Release_Notes_9_0_1.md
@@ -22,7 +22,7 @@
 
 - For 8.0U3 installations: 
     - Occasionally, the plug-in may fail to load on the initial attempt. To check if the plug-in has loaded correctly, click the **vSphere Client** menu icon, then to **Administration** -> **Client** -> **Plug-ins**. Check the Status column of the VMware Local Consumption Interface plug-in, and in case you see a *Plug-in Configuration with Reverse Proxy failed.* message, reinstall the plug-in.
-    - VKS will not support following features:
+    - Following features for VKS are not supported:
         - Ability to retire a TKC and upgrade a TKC from VKr 1.32.x --> 1.33.x is not available.
         - Ability to configure a Windows node pool to use Group Managed Service Accounts.
         - Ability to upgrade a CAPI Cluster with atleast one Ubuntu worker nodes from VKr 1.32.x --> 1.33.x
@@ -34,7 +34,7 @@
 
 - In VKS IaaS plugin:
     - You must enter or modify a new value on any field in the dialog when adding a volume.
-    - To upgrade a Cluster created from a retired TKC, first remove "kubernetes.vmware.com/skip-auto-cc-rebase: ''" annotation by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
+    - If you want to update the Cluster to newer ClusterClass post retiring its TKC, first remove "kubernetes.vmware.com/skip-auto-cc-rebase: ''" annotation by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
     - To upgrade a Cluster to a VKR containing multiple Ubuntu OS versions, add 'os-version' field to the annotations by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
 
 - Resource updates will not automatically refresh in the UI. Users need to use the reload button to refresh the views on the resources.

--- a/consumption-interface/Release_Notes_9_0_1.md
+++ b/consumption-interface/Release_Notes_9_0_1.md
@@ -34,8 +34,8 @@
 
 - In VKS IaaS plugin:
     - You must enter a new value on the volume dialog when adding a volume.
-    - To upgrade a Cluster created from a retired TKC, first remove "kubernetes.vmware.com/skip-auto-cc-rebase: ''" annotation from Cluster yaml before proceeding to upgrade the Cluster.
-    - To upgrade a Cluster to a VKR containing multiple Ubuntu OS versions, first edit the Cluster YAML and add 'os-version' field to the annotation before proceeding to upgrade the Cluster.
+    - To upgrade a Cluster created from a retired TKC, first remove "kubernetes.vmware.com/skip-auto-cc-rebase: ''" annotation by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
+    - To upgrade a Cluster to a VKR containing multiple Ubuntu OS versions, add 'os-version' field to the annotations by editing (and saving) the Cluster YAML via the YAML editor shown on click of "View Yaml" button, before proceeding to upgrade the Cluster.
 
 - Resource updates will not automatically refresh in the UI. Users need to use the reload button to refresh the views on the resources.
 


### PR DESCRIPTION
- We want to call out that LCI 1.0.2 does not support VKS 3.2 features in 8.0.U3 installations.
- Fixed the link to LCI versions from the README file.
- Added section about Cluster retire and upgrades actions under "Known Limitations" in LCI 9.0.1 release notes. 